### PR TITLE
Change client options from sandbox to production urls

### DIFF
--- a/lib/omniauth/strategies/pro_sante_connect.rb
+++ b/lib/omniauth/strategies/pro_sante_connect.rb
@@ -10,9 +10,9 @@ module OmniAuth
       option :authorize_options, [:scope, :acr_values, :response_type]
 
       option :client_options, {
-        site: 'https://auth.bas.esw.esante.gouv.fr',
+        site: 'https://auth.esw.esante.gouv.fr',
         token_url: '/auth/realms/esante-wallet/protocol/openid-connect/token',
-        authorize_url: 'https://wallet.bas.esw.esante.gouv.fr/auth',
+        authorize_url: 'https://wallet.esw.esante.gouv.fr/auth',
       }
 
       info do

--- a/test/test.rb
+++ b/test/test.rb
@@ -7,15 +7,15 @@ end
 
 class ClientTest < StrategyTestCase
   test "has correct pro santé connect site" do
-    assert_equal "https://auth.bas.esw.esante.gouv.fr", strategy.client.site
+    assert_equal "https://auth.esw.esante.gouv.fr", strategy.client.site
   end
 
   test "has correct authorize url" do
-    assert_equal "/oauth/authorize", strategy.client.options[:authorize_url]
+    assert_equal "https://wallet.esw.esante.gouv.fr/auth", strategy.client.options[:authorize_url]
   end
 
   test "has correct token url" do
-    assert_equal "/api/oauth.access", strategy.client.options[:token_url]
+    assert_equal "/auth/realms/esante-wallet/protocol/openid-connect/token", strategy.client.options[:token_url]
   end
 end
 


### PR DESCRIPTION
The url was those of the sandbox environment of Pro Santé Connect. I think that it makes more sense to have the production urls as default and override them with the sandbox ones when needed.