### PR TITLE
Add nonce in authorize_params if provided in request param

### DIFF
--- a/lib/omniauth-pro-sante-connect/version.rb
+++ b/lib/omniauth-pro-sante-connect/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module ProSanteConnect
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end

--- a/lib/omniauth/strategies/pro_sante_connect.rb
+++ b/lib/omniauth/strategies/pro_sante_connect.rb
@@ -20,7 +20,9 @@ module OmniAuth
       end
 
       def authorize_params
-        super.merge(required_options)
+        super
+          .merge({nonce: request.params['nonce']}).compact
+          .merge(required_options)
       end
 
       def callback_url

--- a/lib/omniauth/strategies/pro_sante_connect.rb
+++ b/lib/omniauth/strategies/pro_sante_connect.rb
@@ -5,28 +5,35 @@ require 'rack/utils'
 module OmniAuth
   module Strategies
     class ProSanteConnect < OmniAuth::Strategies::OAuth2
+
       option :name, 'pro-sante-connect'
-
       option :authorize_options, [:scope, :acr_values, :response_type]
-
       option :client_options, {
         site: 'https://auth.esw.esante.gouv.fr',
         token_url: '/auth/realms/esante-wallet/protocol/openid-connect/token',
         authorize_url: 'https://wallet.esw.esante.gouv.fr/auth',
       }
+      option :send_nonce, true
 
       info do
         access_token.get('/auth/realms/esante-wallet/protocol/openid-connect/userinfo').parsed
       end
 
       def authorize_params
-        super
-          .merge({nonce: request.params['nonce']}).compact
-          .merge(required_options)
+        add_nonce if options.send_nonce
+        params = super.merge(required_options)
+        persist_nonce if options.send_nonce
+
+        params
       end
 
       def callback_url
         full_host + script_name + callback_path # Do not include query string
+      end
+
+      def callback_phase
+        verify_nonce! if options.send_nonce
+        super
       end
 
       def required_options
@@ -35,6 +42,20 @@ module OmniAuth
           acr_values: 'eidas2',
           response_type: 'code',
         }
+      end
+
+      def add_nonce
+        options.authorize_params[:nonce] = request.params['nonce'] || SecureRandom.hex(24)
+      end
+
+      def persist_nonce
+        session['omniauth.nonce'] = options.authorize_params[:nonce]
+      end
+
+      def verify_nonce!
+        return if request.params['nonce'] == session.delete('omniauth.nonce')
+
+        fail! :invalid_nonce, CallbackError.new(:invalid_nonce, 'Nonce found in id token is invalid')
       end
     end
   end

--- a/test/support/shared_examples.rb
+++ b/test/support/shared_examples.rb
@@ -27,6 +27,11 @@ module OAuth2StrategyTests
       assert_equal "zip", strategy.authorize_params["baz"]
     end
 
+    test "should include nonce if provided in request param" do
+      @request.params['nonce'] = '123abc'
+      assert_equal '123abc', strategy.authorize_params['nonce']
+    end
+
     test "should include top-level options that are marked as :authorize_options" do
       @options = { :authorize_options => [:scope, :foo], :scope => "bar", :foo => "baz" }
       assert_equal "bar", strategy.authorize_params["scope"]

--- a/test/support/shared_examples.rb
+++ b/test/support/shared_examples.rb
@@ -5,6 +5,7 @@ module OAuth2StrategyTests
       include ClientTests
       include AuthorizeParamsTests
       include CSRFAuthorizeParamsTests
+      include NonceAuthorizeParamsTests
       include TokenParamsTests
     end
   end
@@ -25,11 +26,6 @@ module OAuth2StrategyTests
       @options = { :authorize_params => { :foo => "bar", :baz => "zip" } }
       assert_equal "bar", strategy.authorize_params["foo"]
       assert_equal "zip", strategy.authorize_params["baz"]
-    end
-
-    test "should include nonce if provided in request param" do
-      @request.params['nonce'] = '123abc'
-      assert_equal '123abc', strategy.authorize_params['nonce']
     end
 
     test "should include top-level options that are marked as :authorize_options" do
@@ -82,12 +78,19 @@ module OAuth2StrategyTests
       assert_equal strategy.authorize_params["nonce"], strategy.session["omniauth.nonce"]
     end
 
-    test "should store state in the session when present in request params" do
+    test "should store nonce in the session when present in request params" do
       @request.stubs(:params).returns({ "nonce" => "generatedbyme" })
       refute_empty strategy.authorize_params["nonce"]
       assert_equal "generatedbyme", strategy.authorize_params[:nonce]
       refute_empty strategy.session["omniauth.nonce"]
       assert_equal "generatedbyme", strategy.session["omniauth.nonce"]
+    end
+
+    test "should ignore nonce if send_nonce option is false" do
+      @options = { send_nonce: false }
+      @request.stubs(:params).returns({ "nonce" => "generatedbyme" })
+      assert_nil strategy.authorize_params["nonce"]
+      assert_nil strategy.session["omniauth.nonce"]
     end
   end
 

--- a/test/support/shared_examples.rb
+++ b/test/support/shared_examples.rb
@@ -33,8 +33,8 @@ module OAuth2StrategyTests
     end
 
     test "should include top-level options that are marked as :authorize_options" do
-      @options = { :authorize_options => [:scope, :foo], :scope => "bar", :foo => "baz" }
-      assert_equal "bar", strategy.authorize_params["scope"]
+      @options = { :authorize_options => [:ham, :foo], :ham => "cheese", :foo => "baz" }
+      assert_equal "cheese", strategy.authorize_params["ham"]
       assert_equal "baz", strategy.authorize_params["foo"]
     end
 
@@ -69,6 +69,25 @@ module OAuth2StrategyTests
       refute_equal "foo", strategy.authorize_params[:state]
       refute_empty strategy.session["omniauth.state"]
       refute_equal "foo", strategy.session["omniauth.state"]
+    end
+  end
+
+  module NonceAuthorizeParamsTests
+    extend BlockTestHelper
+
+    test "should store random nonce in the session when none is present in authorize or request params" do
+      assert_includes strategy.authorize_params.keys, "nonce"
+      refute_empty strategy.authorize_params["nonce"]
+      refute_empty strategy.session["omniauth.nonce"]
+      assert_equal strategy.authorize_params["nonce"], strategy.session["omniauth.nonce"]
+    end
+
+    test "should store state in the session when present in request params" do
+      @request.stubs(:params).returns({ "nonce" => "generatedbyme" })
+      refute_empty strategy.authorize_params["nonce"]
+      assert_equal "generatedbyme", strategy.authorize_params[:nonce]
+      refute_empty strategy.session["omniauth.nonce"]
+      assert_equal "generatedbyme", strategy.session["omniauth.nonce"]
     end
   end
 


### PR DESCRIPTION
The nonce parameter is used by the OpenID Connect protocol to prevent replay attack.
This PR includes the `nonce` param in `authorize_params` if it is passed as a param to `/auth/pro-sante-connect`.

